### PR TITLE
Trivial typo fix

### DIFF
--- a/lib/tre-match-parallel.c
+++ b/lib/tre-match-parallel.c
@@ -320,7 +320,7 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
       else
 	{
 	  if (num_tags == 0 || reach_next_i == reach_next)
-	    /* We have found a match. */
+	    /* We have found a match. */
 	    break;
 	}
 


### PR DESCRIPTION
Comment had an ISO-8859-1 encoded non-breaking space, probably unintentional. Replacing it with a regular space makes this an ASCII file (arguably preferred).